### PR TITLE
Feature/string regex

### DIFF
--- a/lib/string.js
+++ b/lib/string.js
@@ -37,6 +37,10 @@ class StringSchema extends BaseSchema {
             return;
         }
 
+        if( key === 'regex' && !( value instanceof RegExp ) ) {
+            value = new RegExp(value);
+        }
+
         return super.updateSchema( state, key, value );
     }
 }

--- a/test/lib/string.test.js
+++ b/test/lib/string.test.js
@@ -96,6 +96,41 @@ describe( 'lib/string', function() {
                     expect( stringSchema.trim.called ).to.be.false;
                 });
             });
+
+            [
+                [ 'normal operation, with regex string', { required: null, trim: false, regex: '^[a-z0-9]+$' } ]
+            ].forEach( function( test ) {
+
+                it( test[0], function() {
+
+                    let stringSchema = { };
+
+                    stringSchema.required = sinon.stub().returns( stringSchema );
+                    stringSchema.regex = sinon.stub().returns( stringSchema );
+
+                    let engine = {
+
+                        string: sinon.stub().returns( stringSchema )
+                    };
+
+                    let instance = new StringSchema();
+
+                    let config = test[1];
+
+                    let schema = instance.parse( config, engine );
+
+                    expect( schema ).to.equal( stringSchema );
+
+                    expect( engine.string.calledOnce ).to.be.true;
+                    expect( engine.string.withArgs().calledOnce ).to.be.true;
+
+                    expect( stringSchema.required.calledOnce ).to.be.true;
+                    expect( stringSchema.required.withArgs().calledOnce ).to.be.true;
+
+                    expect( stringSchema.regex.called ).to.be.true;
+                    expect( stringSchema.regex.withArgs(new RegExp(test[1].regex)).calledOnce ).to.be.true;
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
adds string regex support. Takes input in the form:
```
{
  '@type': 'string',
  'regex': '[a-z0-9]+'
}
```

String is converted to a RegExp object and passed to joi string.regex(pattern).