### PR TITLE
feat: add support to allow function

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -28,7 +28,15 @@ class BaseSchema {
 
             if( value === null ) {
 
-                state.schema = state.schema[ key ]();
+                if( key === 'allow' ) {
+
+                    state.schema = state.schema[ key ]( null );
+
+                } else {
+
+                    state.schema = state.schema[ key ]();
+                    
+                }
             }
             else {
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -17,6 +17,26 @@ function booleanCoverter( value ) {
     return utils.parseBoolean( value );
 }
 
+function allowConverter( value, type ) {
+
+    if( value === 'null' ) {
+
+        return null;
+    }
+
+    if( type === 'number' ) {
+
+        return numberConverter( value );
+    }
+
+    if( type === 'boolean' ) {
+
+        return booleanCoverter( value );
+    }
+    
+    return value;
+}
+
 class Converter {
 
     constructor() {
@@ -35,10 +55,12 @@ class Converter {
             single: booleanCoverter,
             truncate: booleanCoverter,
             isRaw: booleanCoverter,
+
+            allow: allowConverter,
         };
     }
 
-    convert( key, value ) {
+    convert( key, value, type ) {
 
         let converterFunc = this.converterMap[ key ];
 
@@ -47,7 +69,7 @@ class Converter {
             return value;
         }
 
-        return converterFunc( value );
+        return converterFunc( value, type );
     }
 }
 
@@ -66,7 +88,7 @@ function convert( type, key, value ) {
         converter = converters._default;
     }
 
-    return converter.convert( key, value );
+    return converter.convert( key, value, type );
 }
 
 module.exports = convert;

--- a/test/lib/base.test.js
+++ b/test/lib/base.test.js
@@ -56,6 +56,27 @@ describe( 'lib/base', function() {
 
                 expect( specialSchema.withParam.calledOnce ).to.be.true;
                 expect( specialSchema.withParam.withArgs( 'param!' ).calledOnce ).to.be.true;
+
+                instance = new BaseSchema( 'allowNull' );
+                specialSchema.allow = sinon.stub().returns( specialSchema );
+
+                engine = {
+                    allowNull: sinon.stub().returns( specialSchema )
+                };
+
+                config =  { '@type': 'number', allow: null }
+                schema = instance.parse( config, engine );
+
+                expect( schema ).to.equal( specialSchema );
+                expect( schema.allow ).to.be.a( 'function' );
+
+                expect( engine.allowNull.calledOnce ).to.be.true;
+                expect( engine.allowNull.withArgs().calledOnce ).to.be.true;
+
+                expect( specialSchema.allow.calledOnce ).to.be.true;
+                expect( specialSchema.allow.withArgs().calledOnce ).to.be.true;
+                expect( specialSchema.allow.withArgs(null).calledOnce ).to.be.true;
+
             });
 
             it( 'unknown method', function() {

--- a/test/lib/convert.test.js
+++ b/test/lib/convert.test.js
@@ -33,6 +33,28 @@ describe( 'lib/convert', function() {
         });
     });
 
+    [ 'allow' ].forEach( function( key ) {
+
+        it( 'allow types: ' + key, function() {
+            
+            expect( convert( 'number', key, '100' ) ).to.equal( 100 );
+            expect( convert( 'number', key, 100 ) ).to.equal( 100 );
+            expect( convert( 'number', key, 'null' ) ).to.be.null;
+
+            expect( convert( 'boolean', key, undefined ) ).to.be.true;
+            expect( convert( 'boolean', key, 'true' ) ).to.be.true;
+            expect( convert( 'boolean', key, true ) ).to.be.true;
+            expect( convert( 'boolean', key, 'null' ) ).to.be.null;
+
+            expect( convert( '_default', key, '100' ) ).to.equal( '100' );
+            expect( convert( '_default', key, 100 ) ).to.equal( 100 );
+            expect( convert( '_default', key, 'true' ) ).to.equal( 'true' );
+            expect( convert( '_default', key, true ) ).to.be.true;
+            expect( convert( '_default', key, 'null' ) ).to.be.null;
+
+        });
+    });
+
     it( 'unknown key', function() {
 
         expect( convert( 'any', 'special', '42' ) ).to.equal( '42' );


### PR DESCRIPTION
This PR adds support to allow function:
```
https://github.com/hapijs/joi/blob/master/API.md#anyallowvalue
````

At this moment, only for single value. 

- Motivation: 

     I need to allow null values for a not required field (https://github.com/hapijs/joi/issues/516), as so:

 _joi_
```javascript
 
     name: Joi.string().allow(null);
```

_joi-json_
```
{ ...
      name: 'string:allow=null'
  ...
}
```

   

Regarding unit tests, I added some test cases only for the classes changed by this PR.