### PR TITLE
support dynamic defaults via registered callback functions

### DIFF
--- a/lib/base.js
+++ b/lib/base.js
@@ -9,14 +9,30 @@ class BaseSchema {
         this.engineFuncName = engineFuncName;
     }
 
-    parse( config, engine ) {
-
+    parse( config, engine, functions ) {
         // Note: Joi will clone objects on changes and thus we need to update the schema reference
         let state = { schema: this._createSchema( engine ), engine };
 
         for( let key in config ) {
+            let value = config[ key ];
 
-            this.updateSchema( state, key, config[ key ] );
+            // handle function default args
+            if( key === "default" ) {
+                const function_match = value.match( /^([a-zA-Z0-9_]+)\(([a-zA-Z0-9_.]+)\)$/ );
+
+                if( function_match ) {
+                    const [ , function_name, function_args ] = function_match;
+                    const f = functions.get( function_name );
+
+                    if( f ) {
+                        value = [ f.bind( null, function_args ), function_name ];
+                    } else {
+                        throw new Error( "unable to locate function with name: " + function_name );
+                    }
+                }
+            }
+
+            this.updateSchema( state, key, value );
         }
 
         return state.schema;
@@ -29,6 +45,10 @@ class BaseSchema {
             if( value === null ) {
 
                 state.schema = state.schema[ key ]();
+            }
+            else if (Array.isArray(value)) {
+
+                state.schema = state.schema[ key ]( ...value );
             }
             else {
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,10 @@ class SchemaBuilder {
             return schema;
         }
     }
+
+    registerFunction( name, f ) {
+        this.parser.registerFunction( name, f );
+    }
 }
 
 function resolveEngines() {

--- a/lib/object.js
+++ b/lib/object.js
@@ -11,7 +11,7 @@ class ObjectSchema extends BaseSchema {
         this.parseSchema = parseSchema;
     }
 
-    parse( config, engine ) {
+    parse( config, engine, functions ) {
 
         // Note: Joi will clone objects on changes and thus we need to update the schema reference
         let state = { schema: engine.object(), engine };
@@ -31,7 +31,7 @@ class ObjectSchema extends BaseSchema {
             else {
 
                 // assume key
-                keys[ key ] = parseSchemaFunc.call( null, value, engine );
+                keys[ key ] = parseSchemaFunc.call( null, value, engine, functions );
             }
         }
 

--- a/lib/parser.js
+++ b/lib/parser.js
@@ -82,7 +82,7 @@ function parseSchemaString( str ) {
     return schema;
 }
 
-function parseSchema( value, engine ) {
+function parseSchema( value, engine, functions ) {
 
     if( utils.isString( value ) ) {
 
@@ -124,7 +124,7 @@ function parseSchema( value, engine ) {
         throw new Error( 'unknown type: ' + type );
     }
 
-    return parser.parse( value, engine );
+    return parser.parse( value, engine, functions );
 }
 
 class Parser {
@@ -137,11 +137,22 @@ class Parser {
         }
 
         this.engine = engine;
+        this.functions = new Map();
     }
 
     parse( value ) {
 
-        return parseSchema( value, this.engine );
+        return parseSchema( value, this.engine, this.functions );
+    }
+
+    registerFunction( name, f ) {
+
+        this.functions.set( name, f );
+    }
+
+    getFunction( name ) {
+
+        this.functions.get( name );
     }
 
     static buildSchema( schemaConfig, engine ) {

--- a/lib/string.js
+++ b/lib/string.js
@@ -11,14 +11,14 @@ class StringSchema extends BaseSchema {
         super( 'string' );
     }
 
-    parse( config, engine ) {
+    parse( config, engine, functions ) {
 
         if( config.trim === null ) {
 
             config.trim = true;
         }
 
-        let schema = super.parse( config, engine );
+        let schema = super.parse( config, engine, functions );
 
         if( config.trim === undefined ) {
 

--- a/test/lib/index.test.js
+++ b/test/lib/index.test.js
@@ -276,5 +276,25 @@ describe( 'lib/index', function() {
             let result3 = joi.validate( 'forty-two', schema );
             expect( result3.error ).to.exist;
         });
+
+        it( 'default functions', function() {
+
+            let f = function() { return parser.parse( 'string:default=some_function(ok)' ) };
+
+            expect( f ).to.throw(Error, "unable to locate function with name: some_function" );
+
+            parser.registerFunction("some_function", val => ({ result: true, val }));
+
+            expect( f ).to.not.throw();
+
+            let schema = f();
+            let result1 = joi.validate( '3952469a-1b45-4d5e-825c-e25ec8b57cf6', schema );
+            expect( result1.error ).to.be.null;
+            expect( result1.value ).to.deep.equal('3952469a-1b45-4d5e-825c-e25ec8b57cf6');
+
+            let result2 = joi.validate( undefined, schema );
+            expect( result2.error ).to.be.null;
+            expect( result2.value ).to.deep.equal({ result: true, val: "ok" });
+        });
     });
 });


### PR DESCRIPTION
Thank you for joi-json.  This package is a missing piece of functionality to joi, in my humble opinion.  The ability to define validation in data structures instead of raw code is a key draw to joi/joi-json.

Unfortunately, there are a few things that joi can do that joi-json cannot.  This PR adds support for dynamic defaults by registering callback functions with the parser that can be invoked if a string is supplied as a default that contains enclosing parentheses.

For example, if we had a list of Express routes with separate validation profiles:

    [
        {
            method: "SEARCH",
            url: "/author",
            validation: {
                page_size: "number:integer,min=1,max=1000,default=50"
            }
        },
        {
            method: "SEARCH",
            url: "/publication",
            validation: {
                page_size: "number:integer,min=1,max=1000,default=50"
            }
        }
    ]

What if we wanted "50" to be a global default defined in a central configuration using the config package, we could define a callback that would pull it from a global configuration:

    const lodash = require("lodash");
    const config = require("config");
    const joijson = require("joi-json").builder();

    joijson.registerFunction("config", path => lodash.get(config, path));

    const schema = joijson.build({
        page_size: "number:integer,min=1,max=1000,default=config(app.default_page_size)"
    });

Pretty powerful, yeah?  