### PR TITLE
feat: add support to strip function

### DIFF
--- a/lib/__tests__/convert.test.js
+++ b/lib/__tests__/convert.test.js
@@ -20,7 +20,7 @@ describe( 'lib/convert', function() {
         });
     });
 
-    [ 'sparse', 'single', 'truncate', 'isRaw' ].forEach( function( key ) {
+    [ 'sparse', 'single', 'truncate', 'isRaw', 'strip' ].forEach( function( key ) {
 
         it( 'boolean type: ' + key, function() {
 

--- a/lib/convert.js
+++ b/lib/convert.js
@@ -51,6 +51,7 @@ class Converter {
             single: booleanCoverter,
             truncate: booleanCoverter,
             isRaw: booleanCoverter,
+            strip: booleanCoverter,
 
             allow: allowConverter,
         };


### PR DESCRIPTION
This PR adds support to strip function:

> [https://github.com/hapijs/joi/blob/master/API.md#anyallowvalue](https://hapi.dev/family/joi/api/?v=17.1.0#anystripenabled)

**Motivation**:
I need to strip values that are not updatable, as so:

_joi:_
```
name: Joi.string().strip()
```

_joi-json_: 
```
{ ...
    name: 'string:strip=true'
 ...
}
```